### PR TITLE
Add the list subcommand to the party command

### DIFF
--- a/src/main/java/xyz/nucleoid/parties/PartyManager.java
+++ b/src/main/java/xyz/nucleoid/parties/PartyManager.java
@@ -12,6 +12,7 @@ import xyz.nucleoid.plasmid.api.util.PlayerRef;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.UUID;
 
 public final class PartyManager {
@@ -218,5 +219,9 @@ public final class PartyManager {
         } else {
             return Collections.singleton(player);
         }
+    }
+
+    public Collection<Party> getAllParties() {
+        return new HashSet<>(this.playerToParty.values());
     }
 }

--- a/src/main/java/xyz/nucleoid/parties/PartyTexts.java
+++ b/src/main/java/xyz/nucleoid/parties/PartyTexts.java
@@ -2,10 +2,14 @@ package xyz.nucleoid.parties;
 
 import java.util.UUID;
 
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import net.minecraft.text.Texts;
+import net.minecraft.util.Formatting;
 import xyz.nucleoid.plasmid.api.game.GameTexts;
+import xyz.nucleoid.plasmid.api.util.PlayerRef;
 
 public final class PartyTexts {
     public static MutableText displayError(PartyError error, ServerPlayerEntity player) {
@@ -70,5 +74,39 @@ public final class PartyTexts {
 
     public static MutableText leftGame(ServerPlayerEntity player) {
         return Text.translatable("text.game_parties.party.left_game", player.getDisplayName());
+    }
+
+    public static MutableText noParties() {
+        return Text.translatable("text.game_parties.party.list.none");
+    }
+
+    public static MutableText listEntry(UUID uuid) {
+        return Text.translatable("text.game_parties.party.list.entry", Texts.bracketedCopyable(uuid.toString()));
+    }
+
+    public static MutableText listMemberEntry(PlayerRef member, MinecraftServer server) {
+        return Text.translatable("text.game_parties.party.list.member.entry", name(member, server));
+    }
+
+    public static MutableText listMemberEntryType(PlayerRef member, MinecraftServer server, Text type) {
+        return Text.translatable("text.game_parties.party.list.member.entry.type", name(member, server), type);
+    }
+
+    public static MutableText listMemberTypeOwner() {
+        return Text.translatable("text.game_parties.party.list.member.type.owner");
+    }
+
+    public static MutableText listMemberTypePending() {
+        return Text.translatable("text.game_parties.party.list.member.type.pending");
+    }
+
+    private static Text name(PlayerRef ref, MinecraftServer server) {
+        var player = ref.getEntity(server);
+        if (player == null) {
+            Text id = Text.literal(ref.id().toString());
+            return Texts.bracketed(id).formatted(Formatting.GRAY);
+        }
+
+        return player.getDisplayName();
     }
 }

--- a/src/main/resources/data/game_parties/lang/en_us.json
+++ b/src/main/resources/data/game_parties/lang/en_us.json
@@ -14,6 +14,12 @@
   "text.game_parties.party.kicked.receiver": "You have been kicked from the party",
   "text.game_parties.party.kicked.sender": "%s has been kicked from the party",
   "text.game_parties.party.leave.success": "%s has left the party!",
+  "text.game_parties.party.list.entry": " - Party %s",
+  "text.game_parties.party.list.member.entry": "   - %s",
+  "text.game_parties.party.list.member.entry.type": "   - %s (%s)",
+  "text.game_parties.party.list.member.type.owner": "owner",
+  "text.game_parties.party.list.member.type.pending": "pending",
+  "text.game_parties.party.list.none": "There are no parties!",
   "text.game_parties.party.transferred.receiver": "%s's party has been transferred to you",
   "text.game_parties.party.transferred.sender": "Your party has been transferred to %s",
   "text.game_parties.party.left_game": "%s left the game and has been removed from the party!"


### PR DESCRIPTION
This pull request introduces `/party list`, an operator-only subcommand that can be used to get information about the currently active parties on a server. This subcommand will be useful when paired in the future with other administrative commands for managing parties.