### PR TITLE
Shuffle team members on game join

### DIFF
--- a/src/main/java/xyz/nucleoid/parties/PartyManager.java
+++ b/src/main/java/xyz/nucleoid/parties/PartyManager.java
@@ -13,6 +13,7 @@ import xyz.nucleoid.plasmid.util.PlayerRef;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.List;
 
 public final class PartyManager {
     private static PartyManager instance;
@@ -34,6 +35,8 @@ public final class PartyManager {
             var partyManager = PartyManager.get(player.server);
 
             var members = partyManager.getPartyMembers(player);
+            Collections.shuffle((List<ServerPlayerEntity>) members);
+            
             additional.addAll(members);
         });
     }


### PR DESCRIPTION
Should fix e.g. suspicious spleef where the party player order is directly put into the new game and thus the same player gets the pickaxe every time.
 
See here: https://github.com/NucleoidMC/spleef/blob/1.19.4/src/main/java/xyz/nucleoid/spleef/game/ToolConfig.java#L35