### PR TITLE
Prevent collecting party members that are already in a game for joins

### DIFF
--- a/src/main/java/xyz/nucleoid/parties/PartyManager.java
+++ b/src/main/java/xyz/nucleoid/parties/PartyManager.java
@@ -8,6 +8,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.plasmid.api.event.GameEvents;
+import xyz.nucleoid.plasmid.api.game.GameSpaceManager;
 import xyz.nucleoid.plasmid.api.util.PlayerRef;
 
 import java.util.Collection;
@@ -35,10 +36,15 @@ public final class PartyManager {
 
         GameEvents.COLLECT_PLAYERS_FOR_JOIN.register((gameSpace, player, additional) -> {
             var partyManager = PartyManager.get(player.server);
+            var gameSpaceManager = GameSpaceManager.get();
 
             var members = partyManager.getPartyMembers(player, true);
-            
-            additional.addAll(members);
+
+            for (var member : members) {
+                if (!gameSpaceManager.inGame(member)) {
+                    additional.add(member);
+                }
+            }
         });
 
         GameEvents.TEAM_SELECTION_LOBBY_FINALIZE.register((gameSpace, allocator, players) -> {


### PR DESCRIPTION
This pull request changes the 'collect players for join' event listener to skip collecting party members that are already in the joined game or another game. This change fixes scenarios where party owners would attempt to join a game a party member is already in and fail, instead receiving a 'You have already joined this game!' error.

This functionality might be possible to implement through a more expressive API in Plasmid, but this implementation works for now.