### PR TITLE
Notify rejoining players about pending party invites

### DIFF
--- a/src/main/java/xyz/nucleoid/parties/Party.java
+++ b/src/main/java/xyz/nucleoid/parties/Party.java
@@ -27,6 +27,10 @@ public final class Party {
         this.uuid = UUID.randomUUID();
     }
 
+    PlayerRef getOwner() {
+        return this.owner;
+    }
+
     void setOwner(PlayerRef owner) {
         this.owner = owner;
         this.add(owner);
@@ -63,6 +67,10 @@ public final class Party {
 
     public boolean contains(PlayerRef player) {
         return this.memberPlayers.contains(player);
+    }
+
+    public boolean isInvited(PlayerRef player) {
+        return this.pendingMembers.contains(player);
     }
 
     public boolean isOwner(PlayerRef from) {


### PR DESCRIPTION
Currently, players that have been invited to a party can join the party even after rejoining using `/party accept`. This pull request expands this functionality to the party invite notification system, meaning players will be able to click a link in the chat to join a party they have been invited to even after rejoining.